### PR TITLE
Add Avro Schema Generation

### DIFF
--- a/src/alluvium/avro.py
+++ b/src/alluvium/avro.py
@@ -1,7 +1,7 @@
 """
 Defines the schema you expect from your CDC events.
 
-Provides synctactic sugar for Any types and Either Types.
+Provides syntactic sugar for Any types and Either Types.
 """
 
 from abc import ABC, abstractmethod
@@ -50,12 +50,6 @@ def resolve_primitive_type(avro_type: Union[AvroPrimitiveType, AvroCustomType]):
     raise ValueError("Invalid base type provided")
 
 
-class FieldOrdering(Enum):
-    ASCENDING = "ascending"
-    DESCENDING = "descending"
-    IGNORE = "ignore"
-
-
 class AvroSchema(ABC):
     def __init__(self, avro_type: Union[AvroPrimitiveType, AvroComplexType]):
         self.type = avro_type
@@ -65,18 +59,24 @@ class AvroSchema(ABC):
         pass
 
 
+class FieldOrdering(Enum):
+    ASCENDING = "ascending"
+    DESCENDING = "descending"
+    IGNORE = "ignore"
+
+
 class AvroRecordField(object):
     def __init__(
         self,
         name: str,
-        avro_type: Union[AvroSchema, AvroPrimitiveType],
+        avro_field_type: Union[AvroSchema, AvroPrimitiveType],
         doc: str = None,
         default: Any = None,
         order: FieldOrdering = None,
         aliases: List[str] = None,
     ):
         self.name = name
-        self.avro_type = avro_type
+        self.avro_field_type = avro_field_type
         self.doc = doc
         self.default = default
         self.order = order
@@ -84,9 +84,9 @@ class AvroRecordField(object):
 
     def generate_avro_field(self):
         base = {
-            "type": resolve_primitive_type(self.avro_type)
-            if isinstance(self.avro_type, (AvroPrimitiveType, AvroCustomType))
-            else self.avro_type.avro_schema(),
+            "type": resolve_primitive_type(self.avro_field_type)
+            if isinstance(self.avro_field_type, (AvroPrimitiveType, AvroCustomType))
+            else self.avro_field_type.avro_schema(),
             "name": self.name,
         }
         if self.doc:

--- a/src/alluvium/avro.py
+++ b/src/alluvium/avro.py
@@ -1,0 +1,251 @@
+"""
+Defines the schema you expect from your CDC events.
+
+Provides synctactic sugar for Any types and Either Types.
+"""
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, List, Optional, Union
+
+
+class InvalidSchemaException(Exception):
+    def __init__(self, field_type, message, name=None):
+        self.error_field_type = field_type
+        self.name = name
+        super(InvalidSchemaException, self).__init__(
+            self, "Error with field <{} {}>. {}".format(field_type, name, message)
+        )
+
+
+class AvroPrimitiveType(Enum):
+    NULL = "null"
+    BOOLEAN = "boolean"
+    INTEGER = "int"
+    LONG = "long"
+    FLOAT = "float"
+    DOUBLE = "double"
+    BYTES = "bytes"
+    STRING = "string"
+
+
+class AvroComplexType(Enum):
+    RECORD = "record"
+    ENUM = "enum"
+    ARRAY = "array"
+    MAP = "map"
+    UNIONS = "unions"
+    FIXED = "fixed"
+
+
+class AvroCustomType(Enum):
+    ANY = "any"
+
+
+def resolve_primitive_type(avro_type: Union[AvroPrimitiveType, AvroCustomType]):
+    if isinstance(avro_type, AvroPrimitiveType):
+        return avro_type.value
+    if avro_type == AvroCustomType.ANY:
+        return AvroUnionSchema([primitive for primitive in AvroPrimitiveType]).avro_schema()
+    raise ValueError("Invalid base type provided")
+
+
+class FieldOrdering(Enum):
+    ASCENDING = "ascending"
+    DESCENDING = "descending"
+    IGNORE = "ignore"
+
+
+class AvroSchema(ABC):
+    def __init__(self, avro_type: Union[AvroPrimitiveType, AvroComplexType]):
+        self.type = avro_type
+
+    @abstractmethod
+    def avro_schema(self):
+        pass
+
+
+class AvroRecordField(object):
+    def __init__(
+        self,
+        name: str,
+        avro_type: Union[AvroSchema, AvroPrimitiveType],
+        doc: str = None,
+        default: Any = None,
+        order: FieldOrdering = None,
+        aliases: List[str] = None,
+    ):
+        self.name = name
+        self.avro_type = avro_type
+        self.doc = doc
+        self.default = default
+        self.order = order
+        self.aliases = aliases
+
+    def generate_avro_field(self):
+        base = {
+            "type": resolve_primitive_type(self.avro_type)
+            if isinstance(self.avro_type, (AvroPrimitiveType, AvroCustomType))
+            else self.avro_type.avro_schema(),
+            "name": self.name,
+        }
+        if self.doc:
+            base["doc"] = self.doc
+        if self.default:
+            base["default"] = self.default
+        if self.order:
+            base["order"] = self.order.value
+        if self.aliases:
+            base["aliases"] = self.aliases
+        return base
+
+
+class AvroRecordSchema(AvroSchema):
+    avro_type = AvroComplexType.RECORD
+
+    def __init__(
+        self,
+        name: str,
+        fields: List[AvroRecordField],
+        namespace: str = None,
+        doc: str = None,
+        aliases: List[str] = None,
+    ):
+        if not fields:
+            raise InvalidSchemaException(
+                self.avro_type, "Cannot provide a record schema without any fields.", name=name
+            )
+        self.name = name
+        self.fields = fields
+        self.namespace = namespace
+        self.doc = doc
+        self.aliases = aliases
+
+    def avro_schema(self):
+        base = {
+            "type": self.avro_type.value,
+            "name": self.name,
+            "fields": [field.generate_avro_field() for field in self.fields],
+        }
+        if self.doc:
+            base["doc"] = self.doc
+        if self.namespace:
+            base["namespace"] = self.namespace
+        if self.aliases:
+            base["aliases"] = self.aliases
+        return base
+
+
+class AvroArraySchema(AvroSchema):
+    avro_type = AvroComplexType.ARRAY
+
+    def __init__(self, items: Union[AvroSchema, AvroPrimitiveType]):
+        self.items = items
+
+    def avro_schema(self):
+        return {
+            "type": self.avro_type.value,
+            "items": resolve_primitive_type(self.items)
+            if isinstance(self.items, (AvroPrimitiveType, AvroCustomType))
+            else self.items.avro_schema(),
+        }
+
+
+class AvroMapSchema(AvroSchema):
+    avro_type = AvroComplexType.MAP
+
+    def __init__(self, values: Union[AvroSchema, AvroPrimitiveType]):
+        self.values = values
+
+    def avro_schema(self):
+        return {
+            "type": self.avro_type.value,
+            "values": resolve_primitive_type(self.values)
+            if isinstance(self.values, (AvroPrimitiveType, AvroCustomType))
+            else self.values.avro_schema(),
+        }
+
+
+class AvroUnionSchema(AvroSchema):
+    avro_type = AvroComplexType.UNIONS
+
+    def __init__(self, elements: List[Union[AvroSchema, AvroPrimitiveType]]):
+        if not elements:
+            raise InvalidSchemaException(
+                self.avro_type, "Cannot provide a union schema without any values."
+            )
+        self.elements = elements
+
+    def avro_schema(self):
+        return [
+            resolve_primitive_type(element)
+            if isinstance(element, (AvroPrimitiveType, AvroCustomType))
+            else element.avro_schema()
+            for element in self.elements
+        ]
+
+
+class AvroFixedSchema(AvroSchema):
+    avro_type = AvroComplexType.FIXED
+
+    def __init__(self, name: str, size: int, namespace: str = None, aliases: List[str] = None):
+        self.name = name
+        self.size = size
+        self.namespace = namespace
+        self.aliases = aliases
+
+    def avro_schema(self):
+        base = {"type": self.avro_type.value, "name": self.name, "size": self.size}
+        if self.namespace:
+            base["namespace"] = self.namespace
+        if self.aliases:
+            base["aliases"] = self.aliases
+        return base
+
+
+class AvroEnumSchema(AvroSchema):
+    avro_type = AvroComplexType.ENUM
+
+    def __init__(
+        self,
+        name: str,
+        symbols: List[str],
+        namespace: str = None,
+        aliases: List[str] = None,
+        doc: str = None,
+        default: str = None,
+    ):
+        self.name = name
+        if not symbols:
+            raise InvalidSchemaException(
+                self.avro_type, "Must provide symbols to your enum symbol array.", self.name
+            )
+        if len(symbols) != len(set(symbols)):
+            raise InvalidSchemaException(
+                self.avro_type, "No duplicate symbols allowed for enum schema.", self.name
+            )
+        self.symbols = symbols
+        self.namespace = namespace
+        self.aliases = aliases
+        self.doc = doc
+        if default and default not in symbols:
+            raise InvalidSchemaException(
+                self.avro_type,
+                "Provided default {} which must be in the possible symbols {}".format(
+                    default, self.symbols
+                ),
+                self.name,
+            )
+        self.default = default
+
+    def avro_schema(self):
+        base = {"name": self.name, "type": self.avro_type.value, "symbols": self.symbols}
+        if self.namespace:
+            base["namespace"] = self.namespace
+        if self.aliases:
+            base["aliases"] = self.aliases
+        if self.doc:
+            base["doc"] = self.doc
+        if self.default:
+            base["default"] = self.default
+        return base

--- a/tests/test_avro.py
+++ b/tests/test_avro.py
@@ -100,9 +100,9 @@ def test_record_schema_ok():
     schema = AvroRecordSchema(
         name="order",
         fields=[
-            AvroRecordField(name="order_id", avro_type=AvroPrimitiveType.INTEGER),
+            AvroRecordField(name="order_id", avro_field_type=AvroPrimitiveType.INTEGER),
             AvroRecordField(
-                name="product_ids", avro_type=AvroArraySchema(items=AvroPrimitiveType.INTEGER)
+                name="product_ids", avro_field_type=AvroArraySchema(items=AvroPrimitiveType.INTEGER)
             ),
         ],
     )
@@ -120,7 +120,7 @@ def test_record_schema_ok():
     "optional_kwargs", [{"doc": "foo"}, {"default": "foo"}, {"aliases": ["foo"]}]
 )
 def test_record_field_optional_ok(optional_kwargs):
-    field = AvroRecordField(name="order_id", avro_type=AvroPrimitiveType.STRING, **optional_kwargs)
+    field = AvroRecordField(name="order_id", avro_field_type=AvroPrimitiveType.STRING, **optional_kwargs)
     base = {"name": "order_id", "type": "string"}
     base.update(optional_kwargs)
     assert field.generate_avro_field() == base
@@ -132,7 +132,7 @@ def test_record_field_optional_ok(optional_kwargs):
 def test_record_schema_optional_ok(optional_kwargs):
     schema = AvroRecordSchema(
         name="order",
-        fields=[AvroRecordField(name="order_id", avro_type=AvroPrimitiveType.INTEGER)],
+        fields=[AvroRecordField(name="order_id", avro_field_type=AvroPrimitiveType.INTEGER)],
         **optional_kwargs
     )
     base = {"type": "record", "name": "order", "fields": [{"name": "order_id", "type": "int"}]}

--- a/tests/test_avro.py
+++ b/tests/test_avro.py
@@ -1,0 +1,153 @@
+import pytest
+
+from alluvium.avro import (
+    AvroArraySchema,
+    AvroComplexType,
+    AvroCustomType,
+    AvroEnumSchema,
+    AvroFixedSchema,
+    AvroMapSchema,
+    AvroPrimitiveType,
+    AvroRecordField,
+    AvroRecordSchema,
+    AvroUnionSchema,
+    FieldOrdering,
+    InvalidSchemaException,
+)
+
+
+def test_enum_schema_ok():
+    schema = AvroEnumSchema("metasyntactic_enums", symbols=["FOO", "BAR", "BAZ"])
+    assert schema.avro_schema() == {
+        "name": "metasyntactic_enums",
+        "type": "enum",
+        "symbols": ["FOO", "BAR", "BAZ"],
+    }
+
+
+@pytest.mark.parametrize(
+    "optional_kwargs", [{"namespace": "meta"}, {"aliases": ["coolio"]}, {"doc": "doc.com"}]
+)
+def test_enum_schema_ok_optional(optional_kwargs):
+    schema = AvroEnumSchema("metasyntactic_enums", symbols=["FOO", "BAR", "BAZ"], **optional_kwargs)
+    base = {"name": "metasyntactic_enums", "type": "enum", "symbols": ["FOO", "BAR", "BAZ"]}
+    base.update(optional_kwargs)
+    assert schema.avro_schema() == base
+
+
+@pytest.mark.parametrize(
+    "bad_kwargs",
+    [
+        {"symbols": ["FOO", "BAR", "BAZ", "FOO"]},
+        {"symbols": []},
+        {"symbols": ["FOO", "BAR", "BAZ"], "default": "QUX"},
+    ],
+)
+def test_enum_schema_error(bad_kwargs):
+    with pytest.raises(InvalidSchemaException):
+        AvroEnumSchema("metasyntactic_enums", **bad_kwargs)
+
+
+def test_fixed_schema_ok():
+    schema = AvroFixedSchema("stable", 12)
+    assert schema.avro_schema() == {"name": "stable", "size": 12, "type": "fixed"}
+
+
+@pytest.mark.parametrize("optional_kwargs", [{"namespace": "foo"}, {"aliases": ["alias"]}])
+def test_fixed_schema_optional(optional_kwargs):
+    schema = AvroFixedSchema("stable", 12, **optional_kwargs)
+    base = {"name": "stable", "size": 12, "type": "fixed"}
+    base.update(optional_kwargs)
+    assert schema.avro_schema() == base
+
+
+def test_union_schema_ok():
+    schema = AvroUnionSchema(elements=[AvroPrimitiveType.INTEGER, AvroPrimitiveType.LONG])
+    assert schema.avro_schema() == ["int", "long"]
+
+    schema = AvroUnionSchema(elements=[AvroPrimitiveType.INTEGER, AvroFixedSchema("stable", 12)])
+    assert schema.avro_schema() == ["int", {"name": "stable", "size": 12, "type": "fixed"}]
+
+
+def test_union_schema_bad():
+    with pytest.raises(InvalidSchemaException):
+        AvroUnionSchema(elements=[])
+
+
+def test_map_schema_ok():
+    schema = AvroMapSchema(values=AvroPrimitiveType.INTEGER)
+    assert schema.avro_schema() == {"type": "map", "values": "int"}
+
+    schema = AvroMapSchema(values=AvroFixedSchema("stable", 12))
+    assert schema.avro_schema() == {
+        "type": "map",
+        "values": {"name": "stable", "size": 12, "type": "fixed"},
+    }
+
+
+def test_array_schema_ok():
+    schema = AvroArraySchema(items=AvroPrimitiveType.STRING)
+    assert schema.avro_schema() == {"type": "array", "items": "string"}
+
+    schema = AvroArraySchema(items=AvroFixedSchema("stable", 12))
+    assert schema.avro_schema() == {
+        "type": "array",
+        "items": {"name": "stable", "size": 12, "type": "fixed"},
+    }
+
+
+def test_record_schema_ok():
+    schema = AvroRecordSchema(
+        name="order",
+        fields=[
+            AvroRecordField(name="order_id", avro_type=AvroPrimitiveType.INTEGER),
+            AvroRecordField(
+                name="product_ids", avro_type=AvroArraySchema(items=AvroPrimitiveType.INTEGER)
+            ),
+        ],
+    )
+    assert schema.avro_schema() == {
+        "type": "record",
+        "name": "order",
+        "fields": [
+            {"name": "order_id", "type": "int"},
+            {"name": "product_ids", "type": {"type": "array", "items": "int"}},
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "optional_kwargs", [{"doc": "foo"}, {"default": "foo"}, {"aliases": ["foo"]}]
+)
+def test_record_field_optional_ok(optional_kwargs):
+    field = AvroRecordField(name="order_id", avro_type=AvroPrimitiveType.STRING, **optional_kwargs)
+    base = {"name": "order_id", "type": "string"}
+    base.update(optional_kwargs)
+    assert field.generate_avro_field() == base
+
+
+@pytest.mark.parametrize(
+    "optional_kwargs", [{"doc": "foo"}, {"namespace": "foo"}, {"aliases": ["foo"]}]
+)
+def test_record_schema_optional_ok(optional_kwargs):
+    schema = AvroRecordSchema(
+        name="order",
+        fields=[AvroRecordField(name="order_id", avro_type=AvroPrimitiveType.INTEGER)],
+        **optional_kwargs
+    )
+    base = {"type": "record", "name": "order", "fields": [{"name": "order_id", "type": "int"}]}
+    base.update(optional_kwargs)
+    assert schema.avro_schema() == base
+
+
+def test_record_schema_no_fields():
+    with pytest.raises(InvalidSchemaException):
+        AvroRecordSchema(name="foo", fields=[])
+
+
+def test_all_custom_type():
+    schema = AvroArraySchema(items=AvroCustomType.ANY)
+    assert schema.avro_schema() == {
+        "type": "array",
+        "items": ["null", "boolean", "int", "long", "float", "double", "bytes", "string"],
+    }


### PR DESCRIPTION
**Context**

This is some pre-work which will simplify a lot of the ETL code we are going to write to process CDC Events into something useful.

**Reference Issue**: https://github.com/themissinghlink/alluvium/issues/7

**Problem**

According to the avro spec. An Avro schema is a dictionary with a mandatory key of name "type". The value of this is either a Primitive Type (int, str, etc.) or a Derived Type which is yet another avro schema (Records, Arrays, Maps, etc.). 

This revision tries to build a schema generation library for reading and writing validated avro files. This revision introduces the following 

1. An `AvroSchema` abstract class. This defines the avro_schema abstract method which needs to be implemented. All special schemas will inherit from this abstract class. Just like the spec, the `AvroSchema` has a avro_type attribute which points to the type that the schema expects. 

2. Avro Types. These are Enums which belong to `AvroPrimitiveType` or `AvroComplexType`. `AvroCustomTypes` are treated as special primitive types which are handled in `resolve_primitive_type`.

Based on these ideas, this revision implements each and every Derived Type schema and serializes these objects into an avro compatible json string. With this you should be able to construct manageable avro schema's with reusable pieces.