### PR TITLE
Add S3 Utility Support and Moto Testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,8 @@
-
+boto3==1.14.6             # via alluvium (setup.py)
+botocore==1.17.6          # via boto3, s3transfer
+docutils==0.15.2          # via botocore
+jmespath==0.10.0          # via boto3, botocore
+python-dateutil==2.8.1    # via botocore
+s3transfer==0.3.3         # via boto3
+six==1.15.0               # via python-dateutil
+urllib3==1.25.9           # via botocore

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = []
+install_requires = ['boto3',]
 dev_requires = install_requires + [
     "autopep8>=1.4.4",
     'black>=18.0.b0,<19;python_version>="3.6"',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = ['boto3',]
+install_requires = ["boto3"]
 dev_requires = install_requires + [
     "autopep8>=1.4.4",
     'black>=18.0.b0,<19;python_version>="3.6"',

--- a/src/alluvium/aws.py
+++ b/src/alluvium/aws.py
@@ -1,10 +1,12 @@
 import os
 from datetime import datetime
-from json import dumps, JSONDecodeError, JSONDecoder, loads
-from tempfile import TemporaryFile
+from json import dumps, JSONDecodeError, JSONDecoder, load, loads
+from tempfile import NamedTemporaryFile, TemporaryFile
 from typing import Any, Dict, List
 
 import boto3
+
+from alluvium.serdes import decode_new_line_delimited_json, decode_non_delimited_json
 
 
 """
@@ -12,58 +14,54 @@ Convenience wrapper for common operations on AWS.
 """
 
 
-def decode_non_delimited_json(content_unicode_str):
-    decoder = JSONDecoder()
-    decode_index, content_length = 0, len(content_unicode_str)
-
-    objects = []
-    while decode_index < content_length:
-        try:
-            obj, decode_index = decoder.raw_decode(content_unicode_str, decode_index)
-            objects.append(obj)
-        except JSONDecodeError:
-            # Scan forward and keep trying to decode
-            decode_index += 1
-    return objects
+def get_s3_bucket(bucket_name: str):
+    return boto3.resource("s3").Bucket(bucket_name)
 
 
-def decode_new_line_delimited_json(content_fp):
-    return [loads(line) for line in content_fp]
+def create_s3_object(bucket_name: str, key: str):
+    return boto3.resource("s3").Object(bucket_name, key)
 
 
-class S3Bucket(object):
-    def __init__(self, bucket_name: str):
-        self.bucket_name = bucket_name
-        self.client = boto3.resource("s3")
-        self.bucket = self.client.Bucket(bucket_name)
+def get_s3_keys_with_prefix(bucket_name: str, prefix: str):
+    s3_bucket = get_s3_bucket(bucket_name)
+    return s3_bucket.objects.filter(Prefix=prefix)
 
-    def get_keys_with_prefix(self, prefix: str):
-        """
-        Returns a generator which contains a list of keys.
-        """
-        return self.bucket.objects.filter(Prefix=prefix)
 
-    def get_nondelimited_json_objects_from_key(self, key: str) -> Dict[Any, Any]:
-        outputs = []
-        with TemporaryFile(mode="w+b") as fp:
-            self.bucket.download_fileobj(key, fp)
-            fp.seek(0)
-            outputs = decode_non_delimited_json(fp.read().decode("utf8").replace("'", '"'))
-        return outputs
+def get_json_from_key(bucket_name: str, key: str) -> Dict[Any, Any]:
+    s3_bucket = get_s3_bucket(bucket_name)
+    with NamedTemporaryFile(mode="w+b") as fp:
+        s3_bucket.download_fileobj(key, fp)
+        fp.seek(0)
+        with open(fp.name, "r") as inner_fp:
+            outputs = load(inner_fp)
+    return outputs
 
-    def get_new_line_delimited_json_objects_from_key(self, key: str) -> Dict[Any, Any]:
-        outputs = []
-        with TemporaryFile(mode="w+b") as fp:
-            self.bucket.download_fileobj(key, fp)
-            fp.seek(0)
-            outputs = decode_new_line_delimited_json(fp)
-        return outputs
 
-    def upload_file_to_key(self, path_to_upload_file: str, key: str):
-        if not os.path.exists(path_to_upload_file):
-            raise ValueError(
-                "Can't upload to {}. Filepath {} doesn't exist.".format(key, path_to_upload_file)
-            )
-        key = self.client.Object(self.bucket_name, key)
-        with open(path_to_upload_file, "rb") as fp:
-            key.put(Body=fp)
+def get_nondelimited_json_objects_from_key(bucket_name: str, key: str) -> Dict[Any, Any]:
+    s3_bucket = get_s3_bucket(bucket_name)
+    outputs = []
+    with TemporaryFile(mode="w+b") as fp:
+        s3_bucket.download_fileobj(key, fp)
+        fp.seek(0)
+        outputs = decode_non_delimited_json(fp.read().decode("utf8").replace("'", '"'))
+    return outputs
+
+
+def get_new_line_delimited_json_objects_from_key(bucket_name: str, key: str) -> Dict[Any, Any]:
+    s3_bucket = get_s3_bucket(bucket_name)
+    outputs = []
+    with TemporaryFile(mode="w+b") as fp:
+        s3_bucket.download_fileobj(key, fp)
+        fp.seek(0)
+        outputs = decode_new_line_delimited_json(fp)
+    return outputs
+
+
+def upload_file_to_key(bucket_name: str, path_to_upload_file: str, key: str):
+    if not os.path.exists(path_to_upload_file):
+        raise OSError(
+            "Can't upload to {}. Filepath {} doesn't exist.".format(key, path_to_upload_file)
+        )
+    key = create_s3_object(bucket_name, key)
+    with open(path_to_upload_file, "rb") as fp:
+        key.put(Body=fp)

--- a/src/alluvium/aws.py
+++ b/src/alluvium/aws.py
@@ -1,0 +1,69 @@
+import os
+from datetime import datetime
+from json import dumps, JSONDecodeError, JSONDecoder, loads
+from tempfile import TemporaryFile
+from typing import Any, Dict, List
+
+import boto3
+
+
+"""
+Convenience wrapper for common operations on AWS.
+"""
+
+
+def decode_non_delimited_json(content_unicode_str):
+    decoder = JSONDecoder()
+    decode_index, content_length = 0, len(content_unicode_str)
+
+    objects = []
+    while decode_index < content_length:
+        try:
+            obj, decode_index = decoder.raw_decode(content_unicode_str, decode_index)
+            objects.append(obj)
+        except JSONDecodeError:
+            # Scan forward and keep trying to decode
+            decode_index += 1
+    return objects
+
+
+def decode_new_line_delimited_json(content_fp):
+    return [loads(line) for line in content_fp]
+
+
+class S3Bucket(object):
+    def __init__(self, bucket_name: str):
+        self.bucket_name = bucket_name
+        self.client = boto3.resource("s3")
+        self.bucket = self.client.Bucket(bucket_name)
+
+    def get_keys_with_prefix(self, prefix: str):
+        """
+        Returns a generator which contains a list of keys.
+        """
+        return self.bucket.objects.filter(Prefix=prefix)
+
+    def get_nondelimited_json_objects_from_key(self, key: str) -> Dict[Any, Any]:
+        outputs = []
+        with TemporaryFile(mode="w+b") as fp:
+            self.bucket.download_fileobj(key, fp)
+            fp.seek(0)
+            outputs = decode_non_delimited_json(fp.read().decode("utf8").replace("'", '"'))
+        return outputs
+
+    def get_new_line_delimited_json_objects_from_key(self, key: str) -> Dict[Any, Any]:
+        outputs = []
+        with TemporaryFile(mode="w+b") as fp:
+            self.bucket.download_fileobj(key, fp)
+            fp.seek(0)
+            outputs = decode_new_line_delimited_json(fp)
+        return outputs
+
+    def upload_file_to_key(self, path_to_upload_file: str, key: str):
+        if not os.path.exists(path_to_upload_file):
+            raise ValueError(
+                "Can't upload to {}. Filepath {} doesn't exist.".format(key, path_to_upload_file)
+            )
+        key = self.client.Object(self.bucket_name, key)
+        with open(path_to_upload_file, "rb") as fp:
+            key.put(Body=fp)

--- a/src/alluvium/serdes.py
+++ b/src/alluvium/serdes.py
@@ -1,0 +1,24 @@
+from json import JSONDecodeError, JSONDecoder, loads
+
+
+def decode_non_delimited_json(content_unicode_str):
+    """
+    If you have a non delimited text file with valid json. You can use this
+    to read everything.
+    """
+    decoder = JSONDecoder()
+    decode_index, content_length = 0, len(content_unicode_str)
+
+    objects = []
+    while decode_index < content_length:
+        try:
+            obj, decode_index = decoder.raw_decode(content_unicode_str, decode_index)
+            objects.append(obj)
+        except JSONDecodeError:
+            # Scan forward and keep trying to decode
+            decode_index += 1
+    return objects
+
+
+def decode_new_line_delimited_json(content_fp):
+    return [loads(line) for line in content_fp]

--- a/tests/test_avro.py
+++ b/tests/test_avro.py
@@ -120,7 +120,9 @@ def test_record_schema_ok():
     "optional_kwargs", [{"doc": "foo"}, {"default": "foo"}, {"aliases": ["foo"]}]
 )
 def test_record_field_optional_ok(optional_kwargs):
-    field = AvroRecordField(name="order_id", avro_field_type=AvroPrimitiveType.STRING, **optional_kwargs)
+    field = AvroRecordField(
+        name="order_id", avro_field_type=AvroPrimitiveType.STRING, **optional_kwargs
+    )
     base = {"name": "order_id", "type": "string"}
     base.update(optional_kwargs)
     assert field.generate_avro_field() == base

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,8 +1,36 @@
+import os
+
+import boto3
 import pytest
+import json
+from tempfile import TemporaryFile
 
 from moto import mock_s3
 
 
-@mock_s3
-def test_get_keys_with_prefix(fake_bucket):
-    pass
+@pytest.fixture
+def bucket_name():
+    return 'fake_bucket'
+
+
+@pytest.fixture
+def mock_bucket(bucket_name):
+    with mock_s3():
+        client = boto3.resource("s3")
+        client.create_bucket(Bucket=bucket_name)
+        fake_bucket = client.Bucket(bucket_name)
+        
+        for val in ['bar', 'baz', 'qux']:
+            fake_file_contents = {'foo': val}
+            file_name = '{}.json'.format(val)
+            key = client.Object(bucket_name, file_name)
+            with open(file_name, 'w+') as fp:
+                json.dump(fake_file_contents, fp)
+            with open(file_name, 'r+b') as fp:
+                key.put(Body=fp)
+            os.remove(file_name)
+        yield fake_bucket
+
+
+def test_get_keys_with_prefix(mock_bucket):
+    assert [o.key for o in mock_bucket.objects.all()] == ['bar.json', 'baz.json', 'qux.json']

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,0 +1,8 @@
+import pytest
+
+from moto import mock_s3
+
+
+@mock_s3
+def test_get_keys_with_prefix(fake_bucket):
+    pass

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,10 +1,17 @@
 import json
 import os
-from tempfile import TemporaryFile
+from tempfile import NamedTemporaryFile
 
 import boto3
 import pytest
 from moto import mock_s3
+
+from alluvium.aws import (
+    get_json_from_key,
+    get_new_line_delimited_json_objects_from_key,
+    get_s3_keys_with_prefix,
+    upload_file_to_key,
+)
 
 
 @pytest.fixture
@@ -13,23 +20,65 @@ def bucket_name():
 
 
 @pytest.fixture
-def mock_bucket(bucket_name):
+def mock_bucket_keys():
+    return ["bar.json", "baz.json", "qux.json"]
+
+
+@pytest.fixture
+def mock_bucket(bucket_name, mock_bucket_keys):
     with mock_s3():
         client = boto3.resource("s3")
         client.create_bucket(Bucket=bucket_name)
         fake_bucket = client.Bucket(bucket_name)
+        keys = []
 
-        for val in ["bar", "baz", "qux"]:
-            fake_file_contents = {"foo": val}
-            file_name = "{}.json".format(val)
+        for i, file_name in enumerate(mock_bucket_keys):
             key = client.Object(bucket_name, file_name)
-            with open(file_name, "w+") as fp:
-                json.dump(fake_file_contents, fp)
-            with open(file_name, "r+b") as fp:
-                key.put(Body=fp)
-            os.remove(file_name)
-        yield fake_bucket
+            with NamedTemporaryFile("w+") as fp:
+                json.dump({"foo": i}, fp)
+                fp.seek(0)
+                with open(fp.name, "rb") as inner_fp:
+                    key.put(Body=inner_fp)
+            keys.append(file_name)
+        yield bucket_name
 
 
-def test_get_keys_with_prefix(mock_bucket):
-    assert [o.key for o in mock_bucket.objects.all()] == ["bar.json", "baz.json", "qux.json"]
+def test_get_keys_with_prefix_ok(mock_bucket, mock_bucket_keys):
+    s3_objects = get_s3_keys_with_prefix(mock_bucket, "")
+    assert [obj.key for obj in s3_objects] == mock_bucket_keys
+    for i, key in enumerate(mock_bucket_keys):
+        assert get_json_from_key(mock_bucket, key) == {"foo": i}
+
+
+def test_get_keys_with_prefix_not_exists(mock_bucket, mock_bucket_keys):
+    s3_objects = get_s3_keys_with_prefix(mock_bucket, "NOT_A_REAL_LOCATION")
+    assert not list(s3_objects)
+
+
+def test_upload_to_s3(mock_bucket):
+    with NamedTemporaryFile("w+") as fp:
+        json.dump({"foo": "bar"}, fp)
+        fp.seek(0)
+        upload_file_to_key(mock_bucket, fp.name, "cool.json")
+    s3_objects = get_s3_keys_with_prefix(mock_bucket, "")
+    assert "cool.json" in [obj.key for obj in s3_objects]
+    assert get_json_from_key(mock_bucket, "cool.json") == {"foo": "bar"}
+
+
+def test_upload_to_s3_not_exists_in_filesystem(mock_bucket):
+    with pytest.raises(OSError):
+        upload_file_to_key(mock_bucket, "NOT_A_REAL_FILE", "cool.json")
+
+
+def test_get_new_line_delimited_json_objects_from_key_ok(mock_bucket):
+    with NamedTemporaryFile("w+") as fp:
+        fp.write(json.dumps({"foo": 0}) + "\n")
+        fp.write(json.dumps({"foo": 1}) + "\n")
+        fp.seek(0)
+        upload_file_to_key(mock_bucket, fp.name, "cool.json")
+    s3_objects = get_s3_keys_with_prefix(mock_bucket, "")
+    assert "cool.json" in [obj.key for obj in s3_objects]
+    assert get_new_line_delimited_json_objects_from_key(mock_bucket, "cool.json") == [
+        {"foo": 0},
+        {"foo": 1},
+    ]

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,16 +1,15 @@
+import json
 import os
+from tempfile import TemporaryFile
 
 import boto3
 import pytest
-import json
-from tempfile import TemporaryFile
-
 from moto import mock_s3
 
 
 @pytest.fixture
 def bucket_name():
-    return 'fake_bucket'
+    return "fake_bucket"
 
 
 @pytest.fixture
@@ -19,18 +18,18 @@ def mock_bucket(bucket_name):
         client = boto3.resource("s3")
         client.create_bucket(Bucket=bucket_name)
         fake_bucket = client.Bucket(bucket_name)
-        
-        for val in ['bar', 'baz', 'qux']:
-            fake_file_contents = {'foo': val}
-            file_name = '{}.json'.format(val)
+
+        for val in ["bar", "baz", "qux"]:
+            fake_file_contents = {"foo": val}
+            file_name = "{}.json".format(val)
             key = client.Object(bucket_name, file_name)
-            with open(file_name, 'w+') as fp:
+            with open(file_name, "w+") as fp:
                 json.dump(fake_file_contents, fp)
-            with open(file_name, 'r+b') as fp:
+            with open(file_name, "r+b") as fp:
                 key.put(Body=fp)
             os.remove(file_name)
         yield fake_bucket
 
 
 def test_get_keys_with_prefix(mock_bucket):
-    assert [o.key for o in mock_bucket.objects.all()] == ['bar.json', 'baz.json', 'qux.json']
+    assert [o.key for o in mock_bucket.objects.all()] == ["bar.json", "baz.json", "qux.json"]


### PR DESCRIPTION
**Issue**: https://github.com/themissinghlink/alluvium/issues/9

**Summary**: When we do any sort of ETL we are going to need to upload and download files from s3. We will also need to be able to marshall these files in different ways so this utility revision adds those fixes.

**changes**

- Added a boto3 dependency to setup.py
- Added an aws.py file which has a bunch of utility functions needed for working with s3.
- added some simple tests that use moto.