### PR TITLE
Add kinesis terraform resources

### DIFF
--- a/terraform/kinesis.tf
+++ b/terraform/kinesis.tf
@@ -1,0 +1,61 @@
+provider "aws" {
+  profile = "default"
+  region  = "us-east-1"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "cdc-event-bucket"
+  acl    = "private"
+}
+
+resource "aws_iam_role" "firehose_role" {
+  name = "firehose_test_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "firehose.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
+  name        = "terraform-kinesis-firehose-extended-s3-test-stream"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.firehose_role.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.kinesis_firehose.name
+      log_stream_name = aws_cloudwatch_log_stream.cdc_events.name
+    }
+  }
+}
+
+
+resource "aws_cloudwatch_log_group" "kinesis_firehose" {
+  name = "kinesis-firehose"
+
+  tags = {
+    Environment = "production"
+    Application = "alluvium"
+  }
+}
+
+
+resource "aws_cloudwatch_log_stream" "cdc_events" {
+  name           = "cdc-events"
+  log_group_name = aws_cloudwatch_log_group.kinesis_firehose.name
+}


### PR DESCRIPTION
⚠️ This depends on https://github.com/themissinghlink/alluvium/pull/1

We ought to allow the demo to work with kinesis as well. I threw down a simple terraform kinesis resource which should setup a S3 destination Bucket and a kinesis firehose. As long as you have your `.aws/credentials` and `.aws/config` setup you should be good to go when you run `terraform init/apply`. 


Here is the terraform plan:


```
  # aws_cloudwatch_log_group.kinesis_firehose will be created
  + resource "aws_cloudwatch_log_group" "kinesis_firehose" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + name              = "kinesis-firehose"
      + retention_in_days = 0
      + tags              = {
          + "Application" = "alluvium"
          + "Environment" = "production"
        }
    }

  # aws_cloudwatch_log_stream.cdc_events will be created
  + resource "aws_cloudwatch_log_stream" "cdc_events" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + log_group_name = "kinesis-firehose"
      + name           = "cdc-events"
    }

  # aws_iam_role.firehose_role will be created
  + resource "aws_iam_role" "firehose_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "firehose.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + max_session_duration  = 3600
      + name                  = "firehose_test_role"
      + path                  = "/"
      + unique_id             = (known after apply)
    }

  # aws_kinesis_firehose_delivery_stream.extended_s3_stream will be created
  + resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
      + arn            = (known after apply)
      + destination    = "extended_s3"
      + destination_id = (known after apply)
      + id             = (known after apply)
      + name           = "terraform-kinesis-firehose-extended-s3-test-stream"
      + version_id     = (known after apply)

      + extended_s3_configuration {
          + bucket_arn         = (known after apply)
          + buffer_interval    = 300
          + buffer_size        = 5
          + compression_format = "UNCOMPRESSED"
          + role_arn           = (known after apply)
          + s3_backup_mode     = "Disabled"

          + cloudwatch_logging_options {
              + enabled         = true
              + log_group_name  = "kinesis-firehose"
              + log_stream_name = "cdc-events"
            }
        }
    }

  # aws_s3_bucket.bucket will be created
  + resource "aws_s3_bucket" "bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = "cdc-event-bucket"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }
    }
```