### PR TITLE
Alluvium Consumer RFC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:12
+
+RUN apt-get update && apt-get install postgresql-12-wal2json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.7"
+
+services:
+  test-postgres-db:
+    build:
+        context: .
+        dockerfile: Dockerfile
+    container_name: test-postgres-db
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: "test"
+      POSTGRES_USER: "test"
+      POSTGRES_DB: "test"
+    networks:
+      - postgres
+    command: postgres -c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10
+
+networks:
+  postgres:
+    driver: bridge
+    name: postgres

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,5 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 boto3==1.14.8             # via alluvium (setup.py)
 botocore==1.17.8          # via boto3, s3transfer
-=======
-boto3==1.14.4             # via alluvium (setup.py)
-botocore==1.17.4          # via boto3, s3transfer
->>>>>>> added consumer logic and replication logic with tests/demo
-=======
-boto3==1.14.4             # via alluvium (setup.py)
-botocore==1.17.4          # via boto3, s3transfer
->>>>>>> 86b7a4fe0222f73ad22fb67a17c5eb5bae5208e5
 docutils==0.15.2          # via botocore
 jmespath==0.10.0          # via boto3, botocore
 psycopg2==2.8.5           # via alluvium (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,9 @@
-
+boto3==1.14.4             # via alluvium (setup.py)
+botocore==1.17.4          # via boto3, s3transfer
+docutils==0.15.2          # via botocore
+jmespath==0.10.0          # via boto3, botocore
+psycopg2==2.8.5           # via alluvium (setup.py)
+python-dateutil==2.8.1    # via botocore
+s3transfer==0.3.3         # via boto3
+six==1.15.0               # via python-dateutil
+urllib3==1.25.9           # via botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 boto3==1.14.8             # via alluvium (setup.py)
 botocore==1.17.8          # via boto3, s3transfer
+=======
+boto3==1.14.4             # via alluvium (setup.py)
+botocore==1.17.4          # via boto3, s3transfer
+>>>>>>> added consumer logic and replication logic with tests/demo
 docutils==0.15.2          # via botocore
 jmespath==0.10.0          # via boto3, botocore
 psycopg2==2.8.5           # via alluvium (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-boto3==1.14.6             # via alluvium (setup.py)
-botocore==1.17.6          # via boto3, s3transfer
+boto3==1.14.8             # via alluvium (setup.py)
+botocore==1.17.8          # via boto3, s3transfer
 docutils==0.15.2          # via botocore
 jmespath==0.10.0          # via boto3, botocore
+psycopg2==2.8.5           # via alluvium (setup.py)
 python-dateutil==2.8.1    # via botocore
 s3transfer==0.3.3         # via boto3
 six==1.15.0               # via python-dateutil

--- a/scripts/generate_cdc_events.py
+++ b/scripts/generate_cdc_events.py
@@ -1,0 +1,57 @@
+import logging
+
+import click
+from psycopg2.extras import LogicalReplicationConnection
+
+from alluvium.consumer import (
+    KinesisFirehoseConsumer,
+    LogConsumer,
+    Wal2JsonProcessorV1,
+    Wal2JsonProcessorV2,
+)
+from alluvium.db_utils import get_database_cursor
+from alluvium.replication import subscribe_to_replication_slot
+
+PG_CONFIG = {
+    "user": "test",
+    "password": "test",
+    "host": "localhost",
+    "port": 5432,
+    "database": "postgres",
+    "connection_factory": LogicalReplicationConnection,
+}
+
+
+FORMAT_VERSION_ARG_TO_PROCESSOR = {"V1": (Wal2JsonProcessorV1, 1), "V2": (Wal2JsonProcessorV2, 2)}
+
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command(name="start_logger_listener")
+@click.option(
+    "--format_version",
+    "-f",
+    type=click.Choice(["V1", "V2"], case_sensitive=False),
+    help="The processor class which ",
+)
+def start_stdout_listener(format_version):
+    processor, fmt_version = FORMAT_VERSION_ARG_TO_PROCESSOR[format_version]
+    logging.info("Starting to listen:")
+    with get_database_cursor(PG_CONFIG) as cursor:
+        subscribe_to_replication_slot(
+            cursor,
+            "alluvium_stdout",
+            LogConsumer(cdc_event_processor=processor),
+            {"pretty-print": 1, "include-schemas": 1, "format-version": fmt_version},
+            True,
+        )
+
+
+if __name__ == "__main__":
+    cli()  # pylint:disable=no-value-for-parameter

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ install_requires = ["boto3", "psycopg2"]
 dev_requires = install_requires + [
     "autopep8>=1.4.4",
     'black>=18.0.b0,<19;python_version>="3.6"',
+    "click",
     "flake8",
     "ipython",
     "isort>=4.3.21",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import find_packages, setup
 
-install_requires = ["boto3"]
+
+install_requires = ["boto3", "psycopg2"]
 dev_requires = install_requires + [
     "autopep8>=1.4.4",
     'black>=18.0.b0,<19;python_version>="3.6"',

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ install_requires = ["boto3", "psycopg2"]
 dev_requires = install_requires + [
     "autopep8>=1.4.4",
     'black>=18.0.b0,<19;python_version>="3.6"',
+    "click",
     "flake8",
     "ipython",
     "isort>=4.3.21",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import find_packages, setup
 
-
 install_requires = ["boto3", "psycopg2"]
 dev_requires = install_requires + [
     "autopep8>=1.4.4",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = []
+install_requires = ["boto3", "psycopg2"]
 dev_requires = install_requires + [
     "autopep8>=1.4.4",
     'black>=18.0.b0,<19;python_version>="3.6"',

--- a/src/alluvium/consumer.py
+++ b/src/alluvium/consumer.py
@@ -1,0 +1,102 @@
+import json
+import logging
+from abc import ABC, abstractmethod, abstractproperty
+from typing import Type, TypeVar
+
+import boto3
+
+
+class CDCEventProcessor(ABC):
+    """Encasulates post processing logic depending on the cdc format you expect to receive from the database."""
+
+    def __init__(self, payload):
+        self.cdc_event = json.loads(payload)
+
+    @abstractproperty
+    def should_keep(self):
+        pass
+
+    @abstractmethod
+    def post_process(self):
+        pass
+
+
+class Wal2JsonProcessorV1(CDCEventProcessor):
+    """
+    Post processing logic for postgres WAL2JSON Format v1.
+
+    Documentation: https://access.crunchydata.com/documentation/wal2json/2.0/
+    """
+
+    def __init__(self, payload):
+        super(Wal2JsonProcessorV1, self).__init__(payload)
+
+    @property
+    def should_keep(self):
+        return bool(self.cdc_event["change"])
+
+    def post_process(self):
+        return self.cdc_event
+
+
+class Wal2JsonProcessorV2(CDCEventProcessor):
+    """
+    Post processing logic for postgres WAL2JSON Format v2.
+
+    Documentation: https://access.crunchydata.com/documentation/wal2json/2.0/
+    """
+
+    IGNORE_ACTIONS = {"B", "C"}
+
+    def __init__(self, payload):
+        super(Wal2JsonProcessorV2, self).__init__(payload)
+
+    @property
+    def should_keep(self):
+        return self.cdc_event["action"] not in self.IGNORE_ACTIONS
+
+    def post_process(self):
+        return self.cdc_event
+
+
+ProcessorType = TypeVar("CDCEventProcessor", bound=CDCEventProcessor)
+
+
+class Consumer(ABC):
+    """Defines the consumer abstract class used by psycopg2's consume_stream."""
+
+    def __init__(self, processor: Type[ProcessorType]):
+        self.processor = processor
+
+    @abstractmethod
+    def __call__(self, consumable):
+        pass
+
+
+class KinesisFirehoseConsumer(Consumer):
+    """Passes post processed CDC Events to Kinesis."""
+
+    def __init__(self, delivery_stream_name: str, cdc_event_processor: Type[ProcessorType]):
+        super(KinesisFirehoseConsumer, self).__init__(cdc_event_processor)
+        self.client = boto3.client("firehose")
+        self.delivery_stream_name = delivery_stream_name
+
+    def __call__(self, consumable):
+        cdc_event = self.processor(consumable.payload)
+        if cdc_event.should_keep:
+            self.client.put_record(
+                DeliveryStreamName=self.delivery_stream_name,
+                Record={"Data": json.dumps(cdc_event.post_process())},
+            )
+
+
+class LogConsumer(Consumer):
+    """Passes post processed CDC Events to logger."""
+
+    def __init__(self, cdc_event_processor: Type[ProcessorType]):
+        super(LogConsumer, self).__init__(cdc_event_processor)
+
+    def __call__(self, consumable):
+        cdc_event = self.processor(consumable.payload)
+        if cdc_event.should_keep:
+            logging.info(cdc_event.post_process())

--- a/src/alluvium/db_utils.py
+++ b/src/alluvium/db_utils.py
@@ -1,0 +1,14 @@
+from contextlib import contextmanager
+from typing import Any, Dict
+
+from psycopg2 import connect
+
+
+@contextmanager
+def get_database_cursor(connection_options: Dict[str, Any], autocommit: bool = False):
+    connection = connect(**connection_options)
+    if hasattr(connection, "autocommit"):
+        connection.autocommit = autocommit
+    with connection.cursor() as cursor:
+        yield cursor
+    connection.close()

--- a/src/alluvium/replication.py
+++ b/src/alluvium/replication.py
@@ -1,0 +1,53 @@
+from contextlib import contextmanager
+from enum import Enum
+from typing import Any, Dict
+
+from psycopg2 import connect
+from psycopg2.extensions import cursor
+
+from alluvium.consumer import Consumer
+from alluvium.db_utils import get_database_cursor
+
+
+class ReplicationSerializationFormat(Enum):
+    WAL2JSON = "wal2json"
+
+
+def replication_slot_exists(slot_name: str, replication_slot_cursor: cursor) -> bool:
+    command = "select count(*) from pg_replication_slots where slot_name='{slot_name}'".format(
+        slot_name=slot_name
+    )
+    replication_slot_cursor.execute(command)
+    count = replication_slot_cursor.fetchone()[0]
+    return count != 0
+
+
+def create_replication_slot(slot_name: str, replication_slot_cursor: cursor, output_format: str):
+    if replication_slot_exists(slot_name, replication_slot_cursor):
+        replication_slot_cursor.drop_replication_slot(slot_name)
+    replication_slot_cursor.create_replication_slot(slot_name, output_plugin=output_format)
+
+
+def start_replication(
+    slot_name: str,
+    replication_slot_cursor: cursor,
+    replication_options: Dict[str, Any],
+    decode: bool = True,
+):
+    create_replication_slot(
+        slot_name, replication_slot_cursor, ReplicationSerializationFormat.WAL2JSON.value
+    )
+    replication_slot_cursor.start_replication(
+        slot_name=slot_name, options=replication_options, decode=decode
+    )
+
+
+def subscribe_to_replication_slot(
+    cursor: cursor,
+    slot_name: str,
+    consumer: Consumer,
+    replication_options: Dict[str, Any],
+    decode: bool = True,
+):
+    start_replication(slot_name, cursor, replication_options, decode)
+    cursor.consume_stream(consumer)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+from alluvium.db_utils import get_database_cursor
+
+TEST_TABLE = "table_with_pk"
+
+
+@pytest.fixture(scope="module")
+def postgres_pg_config():
+    return {
+        "user": "test",
+        "password": "test",
+        "host": "localhost",
+        "port": 5432,
+        "database": "postgres",
+    }
+
+
+@pytest.fixture(scope="module")
+def test_db_cursor(postgres_pg_config):
+    with get_database_cursor(postgres_pg_config, autocommit=True) as cursor:
+        try:
+            cursor.execute(
+                "create table if not exists {}(a serial, b varchar(30), primary key(a));".format(
+                    TEST_TABLE
+                )
+            )
+            yield cursor
+        finally:
+            cursor.execute("drop table if exists {};".format(TEST_TABLE))

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,0 +1,68 @@
+import json
+
+import pytest
+
+from alluvium.consumer import KinesisFirehoseConsumer, Wal2JsonProcessorV1, Wal2JsonProcessorV2
+
+
+@pytest.fixture
+def kinesis_delivery_stream():
+    return "foo-stream"
+
+
+class MockLogicalReplicationEvent(object):
+    def __init__(self, consumable):
+        self.payload = consumable
+
+
+def test_wal_2_json_processor_v1():
+    cdc_event = json.dumps({"change": [{"foo": "bar"}]})
+
+    processor = Wal2JsonProcessorV1(cdc_event)
+    assert processor.should_keep
+    assert processor.post_process() == {"change": [{"foo": "bar"}]}
+
+    cdc_event = json.dumps({"change": []})
+    processor = Wal2JsonProcessorV1(cdc_event)
+    assert not processor.should_keep
+
+
+def test_wal_2_json_processor_v2():
+    cdc_event = json.dumps({"action": "I", "foo": "bar"})
+    processor = Wal2JsonProcessorV2(cdc_event)
+    assert processor.should_keep
+    assert processor.post_process() == {"action": "I", "foo": "bar"}
+
+    cdc_event = json.dumps({"action": "B", "foo": "bar"})
+    processor = Wal2JsonProcessorV2(cdc_event)
+    assert not processor.should_keep
+
+
+def test_kinesis_consumer(mocker, kinesis_delivery_stream):
+    firehose = mocker.MagicMock()
+    boto_calls = mocker.patch("alluvium.consumer.boto3.client", return_value=firehose)
+
+    kinesis_consumer = KinesisFirehoseConsumer(
+        kinesis_delivery_stream, cdc_event_processor=Wal2JsonProcessorV1
+    )
+
+    cdc_event = json.dumps({"change": [{"foo": "bar"}]})
+
+    kinesis_consumer(MockLogicalReplicationEvent(cdc_event))
+    firehose.put_record.assert_called_with(
+        DeliveryStreamName=kinesis_delivery_stream, Record={"Data": cdc_event}
+    )
+
+
+def test_kinesis_consumer_empty_change(mocker, kinesis_delivery_stream):
+    firehose = mocker.MagicMock()
+    boto_calls = mocker.patch("alluvium.consumer.boto3.client", return_value=firehose)
+
+    kinesis_consumer = KinesisFirehoseConsumer(
+        kinesis_delivery_stream, cdc_event_processor=Wal2JsonProcessorV1
+    )
+
+    cdc_event = json.dumps({"change": []})
+
+    kinesis_consumer(MockLogicalReplicationEvent(cdc_event))
+    assert not firehose.put_record.called

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -1,0 +1,68 @@
+import json
+import os
+import sys
+from multiprocessing import Manager, Process
+from time import time
+
+import psycopg2
+import pytest
+from psycopg2.extras import LogicalReplicationConnection
+
+from alluvium.db_utils import get_database_cursor
+from alluvium.replication import (
+    create_replication_slot,
+    replication_slot_exists,
+    ReplicationSerializationFormat,
+    subscribe_to_replication_slot,
+)
+
+# Subscribe to test DB. Start a process which consumes a stream. Then writer will
+TEST_FILE_NAME = "logical_replications.json"
+
+
+@pytest.fixture
+def slot_name():
+    return "test_slot"
+
+
+@pytest.fixture
+def replication_cursor(postgres_pg_config):
+    logical_replication_slot_config_options = postgres_pg_config.copy()
+    logical_replication_slot_config_options.update(
+        {"connection_factory": LogicalReplicationConnection}
+    )
+    with get_database_cursor(logical_replication_slot_config_options) as cursor:
+        yield cursor
+
+
+@pytest.fixture
+def slot_teardown(replication_cursor, slot_name):
+    yield
+    if replication_slot_exists(slot_name, replication_cursor):
+        replication_cursor.drop_replication_slot(slot_name)
+
+
+def test_replication_slot_exists_not_exists(replication_cursor, slot_name):
+    slot_exists = replication_slot_exists(slot_name, replication_cursor)
+    assert not slot_exists
+
+
+def test_replication_slot_exists_exists(replication_cursor, slot_name, slot_teardown):
+    replication_cursor.create_replication_slot(
+        slot_name, output_plugin=ReplicationSerializationFormat.WAL2JSON.value
+    )
+    slot_exists = replication_slot_exists(slot_name, replication_cursor)
+    assert slot_exists
+
+
+def test_create_replication_slot(replication_cursor, slot_name, slot_teardown):
+    assert not replication_slot_exists(slot_name, replication_cursor)
+    create_replication_slot(
+        slot_name, replication_cursor, ReplicationSerializationFormat.WAL2JSON.value
+    )
+    assert replication_slot_exists(slot_name, replication_cursor)
+
+    create_replication_slot(
+        slot_name, replication_cursor, ReplicationSerializationFormat.WAL2JSON.value
+    )
+    assert replication_slot_exists(slot_name, replication_cursor)


### PR DESCRIPTION
This revision introduces 2 abstract classes. And strings everything together with a super simple demo that you need docker/docker-compose to run. 

An Alluvium `Consumer` is an abstract class that takes logical replication events and does something with them. It could either log them to a file. It could send them to a Kinesis firehose. It could send them to Kafka, etc. The surface area is quite wide for this class, so users can extend this however they see fit just as long as they have implemented `__call__` which will be used by psycopg2's `consume_stream` (To be abstracted more heavily when we implement MySQL support. See Maxwell by Zendesk). 

Because different databases and different WAL serialization frameworks have their own ways of representing change data capture, this library introduces the `CDCEventProcessor` abstract class which expects a `post_process` function that let's you encode all of the special sauce you need in order to process your raw cdc events without writing more consumers. (NOTE: If this is designed correctly, the number of Processors >> number of Consumers). 

The rest of the code uses these two classes to get a demo for Postgres LogicalReplication working with Wal2Json. This demo supports both formatting versions seen here: https://access.crunchydata.com/documentation/wal2json/2.0/

**Demo**
First install everything by running `make install` and start your virtualenv.

I threw in a `docker-compose.yml` and a `Dockerfile` so that you can spin up a postgres DB with all of the logical replication settings configured. You can use this for your own configurations as well. Simply run `docker-compose up -d` to spin up your postgres DB with a test db setup. 

You can connect to it via psql by doing the following (password is in `docker-compose`):

```
psql --host=localhost --port=5432 --username=test -d postgres
```

In another tab, you can use the CLI Demo I have provided. Just go into `scripts` and type

```
python generate_cdc_events.py start_logger_listener -f V1
```
and a consumer should start listening. Then go to psql, create a table, and start submitting INSERT's, UPDATE's, and DELETE's and watch everything get logged in STDOUT of your script process to see the handled consumption of your change data capture events.

You can copy the demo provided by WAL2JSON which is in the examples section of [this](https://access.crunchydata.com/documentation/wal2json/2.0/) page.


**Call Outs for reviewer**

- I would like an indication if this demo works another machine and is clear/complete. If this works, I will make a README with that demo. 
- Would also like to see what changes I need to make so that this can be lifted into production code. Right now the exception boundaries are nonexistent. Would love guidance on what that would look like in an ideal situation.
